### PR TITLE
vpn keylength fixed and includes configurable folder

### DIFF
--- a/core/config.ini
+++ b/core/config.ini
@@ -19,3 +19,5 @@ pwdHelp[] = ""
 
 vpnKeyLength = 2048
 sshKeyLength = 2048
+
+vpnFolderPath = "/tmp/vpn"

--- a/core/user.php
+++ b/core/user.php
@@ -74,7 +74,14 @@ class User {
         list ($cert,$priv) = generateSslKeypair($result["sAMAccountName"][0],$result["mail"][0], intval(getConfig("vpnKeyLength")));
         $zip -> addFromString("client.key", $priv);
         $zip -> addFromString("client.crt", $cert);
-        zipFolder($zip, getConfig("vpnFolderPath"));
+        $vpnFolder = getConfig("vpnFolderPath");
+        // fails to generate credentials wihen folder doesn't exist
+        if(file_exists($vpnFolder)){
+            zipFolder($zip,$vpnFolder);
+        }
+        else {
+            throw new Exception("VPN Container is Not Found. Kindly contact the server administrator!")
+        }
         $status = $zip -> close();
         $updateStatus = $this -> updateMyProperty("VPN", $cert);
         if(!$updateStatus){

--- a/core/user.php
+++ b/core/user.php
@@ -71,9 +71,10 @@ class User {
         if ($status !== TRUE){
             throw new Exception("Cannot create Zip File");
         }
-        list ($cert,$priv) = generateSslKeypair($result["sAMAccountName"][0],$result["mail"][0],getConfig("vpnKeyLength"));
+        list ($cert,$priv) = generateSslKeypair($result["sAMAccountName"][0],$result["mail"][0], intval(getConfig("vpnKeyLength")));
         $zip -> addFromString("client.key", $priv);
         $zip -> addFromString("client.crt", $cert);
+        zipFolder($zip, getConfig("vpnFolderPath"));
         $status = $zip -> close();
         $updateStatus = $this -> updateMyProperty("VPN", $cert);
         if(!$updateStatus){
@@ -83,6 +84,7 @@ class User {
         $this -> loggerObj -> log( "VPN Credentials for $this->username have been reset successfully");
         return($zipFilename);
     }
+
     public function getMyAttributes($attrs){
         $ldapObj = new Lucid_LDAP($this->configFile);
         $ldapObj -> bind($this->username, $this->password);

--- a/core/util.php
+++ b/core/util.php
@@ -97,6 +97,26 @@ function randomPassword($len,$complexity=3) {
     }
     return implode($pass); //turn the array into a string
 }
+  //Zips all the files and folders in $folder, using relative path. NOT TESTED WITH LINKS
+  function zipFolder($zipArchive, $folder, $basePath=null){
+    if(!is_dir($folder)){
+        return(-1);
+    }
+    $entries = array_diff(scandir($folder), array('..', '.'));
+    foreach ($entries as $f){
+        $absFilePath = "$folder/$f";
+        if($basePath){
+            $newBasePath = $basePath."/".$f;
+        } else {
+            $newBasePath = $f;
+        }
+        if(is_dir($absFilePath)){
+            zipFolder($zipArchive, $absFilePath, $newBasePath);
+        } else {
+            $zipArchive -> addFile($absFilePath, $newBasePath);
+        }
+    }
+  }
 
 //Returns textual status of the account
 function getAccountStatus($num) {


### PR DESCRIPTION
1) Parses configurable keylength as integer.
2) VPN credentials are changed to include 'vpnFolderPath' by default along with certificate and key.